### PR TITLE
Add type definitions for TypeScript 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+import * as prism from 'prismjs';
+
+export as namespace codeflask
+
+export type LanguageDefinition = {
+  [token: string]: prism.LanguageDefinition | RegExp
+}
+
+export interface CodeFlaskOptions {
+  language?: string
+  rtl?: boolean
+  tabSize?: number
+  enableAutocorrect?: boolean
+  lineNumbers?: boolean
+  defaultTheme?: boolean
+  areaId?: string
+  ariaLabelledby?: string
+  readonly?: boolean
+}
+
+export default class CodeFlask {
+  constructor(selectorOrElement: Element | string, opts: CodeFlaskOptions)
+
+  updateCode(newCode: string): void 
+  updateLanguage(newLanguage: string): void
+  addLanguage(name: string, options: LanguageDefinition): void
+
+  getCode(): string
+  onUpdate(callback: (code: string) => void): void
+
+  disableReadonlyMode(): void
+  enableReadonlyMode(): void
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublishOnly": "npm install && npm run build"
   },
   "dependencies": {
+    "@types/prismjs": "^1.9.1",
     "prismjs": "^1.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Wanted to add type definitions for use with TypeScript.  Any idea how to get this to be included in the build with rollup? 