### PR TITLE
Include type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A micro code-editor for awesome web pages",
   "main": "build/codeflask.min.js",
   "module": "build/codeflask.module.js",
-  "types": "index.d.ts"
+  "types": "index.d.ts",
   "files": [
     "build/codeflask.min.js",
     "build/codeflask.module.js",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "A micro code-editor for awesome web pages",
   "main": "build/codeflask.min.js",
   "module": "build/codeflask.module.js",
+  "types": "index.d.ts"
   "files": [
     "build/codeflask.min.js",
     "build/codeflask.module.js",
+    "index.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
The type file for Typescript is not included in the NPM package. Republishing with the following changes in the package.json file will include the type definitions.